### PR TITLE
Remove redundant `delete` operations.

### DIFF
--- a/lib/managers/StreamingAudioChannel.ts
+++ b/lib/managers/StreamingAudioChannel.ts
@@ -252,13 +252,11 @@ export class StreamingAudioChannel extends BaseAudioChannel implements IAudioCha
 
 			this._sourceBuffer.removeEventListener('updateend', this._updateEndDelegate);
 			this._mediaSource.removeSourceBuffer(this._sourceBuffer);
-			delete this._sourceBuffer;
 			this._sourceBuffer = null;
 		}
 
 		this._mediaSource.removeEventListener('sourceopen', this._sourceOpenDelegate);
 		URL.revokeObjectURL(this._urlString);
-		delete this._mediaSource;
 		this._mediaSource = null;
 	}
 }

--- a/lib/parsers/WaveAudioParser.ts
+++ b/lib/parsers/WaveAudioParser.ts
@@ -33,8 +33,6 @@ export class WaveAudioParser extends ParserBase {
 	}
 
 	protected startParsing(frameLimit: number): void {
-		//clear content
-		delete this._content;
 		this._content = null;
 
 		super.startParsing(frameLimit);


### PR DESCRIPTION
Per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#description), the operator does not actually free memory, but simply removes a reference, allowing it to be garbage collected later. This is similar to the `= null` assignments that happen on the very next lines.